### PR TITLE
Implement basic responsive chat UI

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,11 +2,36 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Poke-Pet</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-
+    <div id="app">
+      <div class="side-panel">
+        <div class="pet-display card"></div>
+        <div class="pet-info card">
+          <div class="info">
+            <p>name:</p>
+            <p>species:</p>
+            <p>gender:</p>
+            <p>owner:</p>
+            <p>last-chatted:</p>
+          </div>
+          <div class="friendship">
+            <label for="friendship">Friendship:</label>
+            <progress id="friendship" value="0" max="100"></progress>
+          </div>
+        </div>
+      </div>
+      <div class="chat-panel card">
+        <div id="chat-log" class="chat-log"></div>
+        <form id="chat-form" class="chat-controls">
+          <input id="chat-input" type="text" placeholder="Value" autocomplete="off" />
+          <button type="submit">✕</button>
+        </form>
+      </div>
+    </div>
     <script type="module" src="scripts/main.js"></script>
   </body>
 </html>

--- a/frontend/public/scripts/main.js
+++ b/frontend/public/scripts/main.js
@@ -1,0 +1,21 @@
+
+const form = document.getElementById('chat-form');
+const input = document.getElementById('chat-input');
+const log = document.getElementById('chat-log');
+
+function appendMessage(sender, text) {
+  const line = document.createElement('div');
+  line.textContent = `${sender}: ${text}`;
+  log.appendChild(line);
+  log.scrollTop = log.scrollHeight;
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+  appendMessage('a', text);
+  appendMessage('b', text);
+  input.value = '';
+});
+

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -1,1 +1,99 @@
+body {
+  margin: 0;
+  background: #555;
+  font-family: sans-serif;
+}
+
+#app {
+  height: 100vh;
+  display: flex;
+  padding: 20px;
+  gap: 20px;
+  box-sizing: border-box;
+}
+
+.card {
+  background: #d3d3d3;
+  border-radius: 15px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  padding: 20px;
+}
+
+.side-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.side-panel .card {
+  flex: 1;
+}
+
+.pet-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.friendship {
+  margin-top: 10px;
+}
+
+.chat-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  height: 50vh;
+  align-self: center;
+}
+
+.chat-log {
+  flex: 1;
+  background: #fff;
+  border-radius: 10px;
+  padding: 10px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+  white-space: pre-wrap;
+}
+
+.chat-controls {
+  display: flex;
+  gap: 10px;
+}
+
+.chat-controls input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+}
+
+.chat-controls button {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 10px;
+  background: #fff;
+  cursor: pointer;
+}
+
+@media (orientation: portrait) {
+  #app {
+    flex-direction: column;
+  }
+  .side-panel {
+    flex-direction: row;
+    height: 25vh;
+  }
+  .side-panel .card {
+    height: 100%;
+  }
+  .chat-panel {
+    width: 100%;
+    height: auto;
+    align-self: stretch;
+    flex: 1;
+  }
+}
 


### PR DESCRIPTION
## Summary
- Add viewport meta for proper scaling
- Refine responsive layout so left info/display stack in landscape and move above chat in portrait

## Testing
- `npm test` in `backend` (fails: Missing script "test")
- `npm test` in `frontend` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c7da5646148322a1ae40552aab094d