### PR TITLE
Display placeholder Pokémon data

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,9 +1,17 @@
 import express from "express";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import "dotenv/config";
 
 const app = express();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 app.use(express.static("public"));
+
+app.get("/pokemon_placeholder.json", (_req, res) => {
+  res.sendFile(path.join(__dirname, "pokemon_placeholder.json"));
+});
 
 const port = Number(process.env.PORT);
 app.listen(port, () => {

--- a/frontend/pokemon_placeholder.json
+++ b/frontend/pokemon_placeholder.json
@@ -3,5 +3,5 @@
   "stage": 2,
   "friendship": 50,
   "last-chatted": "2025-09-15",
-  "context": null,
-} 
+  "context": null
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,16 +9,15 @@
   <body>
     <div id="app">
       <div class="side-panel">
-        <div class="pet-display card"></div>
+        <div class="pet-display card">
+          <img id="pokemon-image" alt="Pokemon" loading="lazy" />
+        </div>
         <div class="pet-info card">
-          <div class="info">
-            <p>name:</p>
-            <p>species:</p>
-            <p>owner:</p>
-            <p>last-chatted:</p>
-          </div>
+          <div class="info" id="pet-info"></div>
           <div class="friendship">
-            <label for="friendship">Friendship:</label>
+            <label class="friendship-label" for="friendship">
+              Friendship: <span id="friendship-value">0</span>/100
+            </label>
             <progress id="friendship" value="0" max="100"></progress>
           </div>
         </div>

--- a/frontend/public/scripts/main.js
+++ b/frontend/public/scripts/main.js
@@ -2,6 +2,103 @@
 const form = document.getElementById('chat-form');
 const input = document.getElementById('chat-input');
 const log = document.getElementById('chat-log');
+const infoContainer = document.getElementById('pet-info');
+const friendshipBar = document.getElementById('friendship');
+const friendshipValueText = document.getElementById('friendship-value');
+const pokemonImage = document.getElementById('pokemon-image');
+
+const stageToImage = {
+  1: 'assets/pichu.png',
+  2: 'assets/pikachu.png',
+  3: 'assets/raichu.png',
+};
+
+const stageToName = {
+  1: 'Pichu',
+  2: 'Pikachu',
+  3: 'Raichu',
+};
+
+function formatInfoValue(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function clampFriendship(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  return Math.min(Math.max(Math.round(numeric), 0), 100);
+}
+
+function renderPokemonInfo(pokemon) {
+  if (!infoContainer) return;
+
+  infoContainer.innerHTML = '';
+
+  Object.entries(pokemon).forEach(([key, value]) => {
+    const displayValue = key === 'friendship' ? clampFriendship(value) : value;
+    const row = document.createElement('div');
+    row.className = 'info-row';
+
+    const label = document.createElement('span');
+    label.className = 'info-label';
+    label.textContent = `${key}:`;
+
+    const infoValue = document.createElement('span');
+    infoValue.className = 'info-value';
+    infoValue.textContent = formatInfoValue(displayValue);
+
+    row.append(label, infoValue);
+    infoContainer.appendChild(row);
+  });
+
+  const stage = Number(pokemon.stage);
+  const imagePath = stageToImage[stage];
+
+  if (pokemonImage) {
+    if (imagePath) {
+      pokemonImage.src = imagePath;
+      const stageName = stageToName[stage] ?? 'Pokemon';
+      pokemonImage.alt = `${stageName} illustration`;
+    } else {
+      pokemonImage.removeAttribute('src');
+      pokemonImage.alt = 'Pokemon';
+    }
+  }
+
+  if (friendshipBar) {
+    const friendshipValue = clampFriendship(pokemon.friendship);
+    friendshipBar.value = friendshipValue;
+    if (friendshipValueText) {
+      friendshipValueText.textContent = String(friendshipValue);
+    }
+  }
+}
+
+async function loadPokemon() {
+  if (!infoContainer) return;
+
+  try {
+    const response = await fetch('/pokemon_placeholder.json', { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Failed to load pokemon: ${response.status}`);
+    }
+    const pokemon = await response.json();
+    renderPokemonInfo(pokemon);
+  } catch (error) {
+    console.error('Unable to load Pokémon data', error);
+    infoContainer.textContent = 'Unable to load Pokémon data.';
+  }
+}
+
+loadPokemon();
 
 function appendMessage(sender, text) {
   const line = document.createElement('div');

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -185,3 +185,79 @@ body {
   }
 }
 
+.pet-display {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pet-display img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.pet-info {
+  gap: 20px;
+}
+
+.info {
+  display: grid;
+  gap: 12px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.info-label {
+  font-weight: 600;
+}
+
+.info-value {
+  margin-left: auto;
+  text-align: right;
+  word-break: break-word;
+}
+
+.friendship {
+  margin-top: 0;
+  padding: 0 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.friendship-label {
+  font-weight: 600;
+}
+
+.friendship progress {
+  width: 100%;
+  height: 1.4em;
+  display: block;
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  overflow: hidden;
+  background-color: transparent;
+}
+
+.friendship progress::-webkit-progress-bar {
+  background-color: #e3e3e3;
+  border-radius: 999px;
+}
+
+.friendship progress::-webkit-progress-value {
+  background-color: #f8d030;
+  border-radius: 999px;
+}
+
+.friendship progress::-moz-progress-bar {
+  background-color: #f8d030;
+  border-radius: 999px;
+}
+


### PR DESCRIPTION
## Summary
- load the placeholder Pokémon JSON on the frontend and populate the info panel dynamically
- render the correct Pokémon sprite for the current evolution stage and surface friendship in a prominent progress bar

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8368b02308322a0650ed1dfbada3d